### PR TITLE
feat: Support creating multiple Todoist tasks from issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,15 @@ gh extension install gaejabong/gh-gt
 ## Usage
 
 ```bash
-# From a repository directory
+# From a repository directory (single or multiple issues)
 gh gt 123
+gh gt 123 124 125
 
 # Specify repository explicitly
-gh gt 45 --repo owner/repo
+gh gt 45 46 --repo owner/repo
 
-# Options
-gh gt 123 --project-id 2293812345 --section-id 99887766 \
+# Options (applied to all issues)
+gh gt 123 124 --project-id 2293812345 --section-id 99887766 \
   --priority 3 --due "next Monday 9am" --labels-as-tags --strip-markdown --open
 ```
 


### PR DESCRIPTION
This pull request adds support for creating multiple Todoist tasks from multiple GitHub issues in a single command. The changes update both the CLI interface and the implementation to handle multiple issue numbers, and introduce a new test to verify this functionality.

**Multi-issue support:**

* The CLI now accepts one or more issue numbers as arguments (`numbers`), allowing users to create tasks for multiple issues at once.
* The main logic in `src/gt/cli.py` is updated to iterate over all provided issue numbers, fetching each issue and creating a corresponding Todoist task. [[1]](diffhunk://#diff-4439e31169e665692cd7289011dfacf472a4ae4a01d6025b8f95f534fb5a87f4L166-L182) [[2]](diffhunk://#diff-4439e31169e665692cd7289011dfacf472a4ae4a01d6025b8f95f534fb5a87f4R185-R208)

**Documentation:**

* The `README.md` usage section is updated to show how to use the tool with multiple issue numbers and options that apply to all issues.

**Testing:**

* A new test `test_cli_creates_multiple_tasks` is added to verify that multiple tasks are created when multiple issue numbers are passed, ensuring the feature works as expected.